### PR TITLE
Hardwire Play apps order in metadata json

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -15,7 +15,7 @@ shutil.rmtree("apps", ignore_errors=True)
 os.mkdir("apps")
 shutil.copy("apps.0.pub", "apps")
 
-apps = {}
+apps = {"com.google.android.gsf": {}, "com.google.android.gms": {}, "com.android.vending": {}}
 
 for channel in channels:
     top = "apps-" + channel


### PR DESCRIPTION
Generate the metadata of Play apps in order they should be installed or updated (on Apps repo client) to activate Google Play compatibility