### PR TITLE
remove the legacy Play Store signature

### DIFF
--- a/apps/packages/com.android.vending/common-props.toml
+++ b/apps/packages/com.android.vending/common-props.toml
@@ -1,4 +1,4 @@
-signatures = ["7ce83c1b71f3d572fed04c8d40c5cb10ff75e6d87d9df6fbd53f0468c2905053","f0fd6c5b410f25cb25c3b53346c8972fae30f8ee7411df910480ad6b2d60db83"]
+signatures = ["7ce83c1b71f3d572fed04c8d40c5cb10ff75e6d87d9df6fbd53f0468c2905053"]
 source = "Google"
 isTopLevel = false
 


### PR DESCRIPTION
f0fd is the old MD5withRSA signature from 2008 that is used for signing Play Store for older devices.
7ce8 is the new SHA256withRSA signature from 2020, it's used on all supported devices.