### PR TITLE
Move to checking webview version for static dependency

### DIFF
--- a/apps/packages/app.vanadium.browser/common-props.toml
+++ b/apps/packages/app.vanadium.browser/common-props.toml
@@ -4,7 +4,7 @@ hasFsVeritySignatures = true
 group = "Vanadium"
 originalPackage = "org.chromium.chrome"
 deps = ["app.vanadium.trichromelibrary", "app.vanadium.webview"]
-staticDeps = ["app.vanadium.browser >= 548106100"]
+staticDeps = ["app.vanadium.webview >= 548106100"]
 
 description = """
 Vanadium is a privacy and security hardened variant of Chromium providing the WebView (used by other apps to render web content) and standard browser for GrapheneOS. It depends on hardening and compatibility fixes in GrapheneOS rather than reinventing the wheel inside Vanadium. For example, GrapheneOS already provides a hardened malloc implementation so there's no need for Vanadium to replace it. Similarly, it can deploy security features causing breakage on other operating systems due to the ability to fix compatibility problems in the OS.

--- a/apps/packages/app.vanadium.trichromelibrary/common-props.toml
+++ b/apps/packages/app.vanadium.trichromelibrary/common-props.toml
@@ -6,4 +6,4 @@ isTopLevel = false
 showAutoUpdateNotifications = false
 isSharedLibrary = true
 noIcon = true
-staticDeps = ["app.vanadium.browser >= 548106100"]
+staticDeps = ["app.vanadium.webview >= 548106100"]

--- a/apps/packages/app.vanadium.webview/common-props.toml
+++ b/apps/packages/app.vanadium.webview/common-props.toml
@@ -6,4 +6,4 @@ noIcon = true
 isTopLevel = false
 showAutoUpdateNotifications = false
 deps = ["app.vanadium.browser", "app.vanadium.trichromelibrary"]
-staticDeps = ["app.vanadium.browser >= 548106100"]
+staticDeps = ["app.vanadium.webview >= 548106100"]


### PR DESCRIPTION
Unlike browser, webview is always installed in managed profiles, and by checking this package instead, Vanadium browser can be installed in these types of profiles.