### PR TITLE
remove isSharedLibrary workaround from VanadiumConfig

### DIFF
--- a/apps/packages/app.vanadium.config/common-props.toml
+++ b/apps/packages/app.vanadium.config/common-props.toml
@@ -4,6 +4,5 @@ hasFsVeritySignatures = true
 group = "Vanadium"
 noIcon = true
 isTopLevel = false
-isSharedLibrary = true
 showAutoUpdateNotifications = false
 staticDeps = ["app.vanadium.webview >= 548106100"]


### PR DESCRIPTION
VanadiumConfig is not a shared library, this workaround was needed to install VanadiumConfig automatically.