### PR TITLE
increase min GmsCompat version to 1007 for all Android Auto releases

### DIFF
--- a/apps/packages/com.google.android.projection.gearhead/110635014/props.toml
+++ b/apps/packages/com.google.android.projection.gearhead/110635014/props.toml
@@ -1,1 +1,0 @@
-channel = "stable"

--- a/apps/packages/com.google.android.projection.gearhead/110635054/props.toml
+++ b/apps/packages/com.google.android.projection.gearhead/110635054/props.toml
@@ -1,1 +1,0 @@
-channel = "stable"

--- a/apps/packages/com.google.android.projection.gearhead/114640814/props.toml
+++ b/apps/packages/com.google.android.projection.gearhead/114640814/props.toml
@@ -1,2 +1,1 @@
-staticDeps = ["app.grapheneos.gmscompat >= 1007"]
 channel = "stable"

--- a/apps/packages/com.google.android.projection.gearhead/common-props.toml
+++ b/apps/packages/com.google.android.projection.gearhead/common-props.toml
@@ -1,7 +1,7 @@
 signatures = ["1ca8dcc0bed3cbd872d2cb791200c0292ca9975768a82d676b8b424fb65b5295"]
 source = "Google"
 
-staticDeps = ["app.grapheneos.gmscompat >= 1006"]
+staticDeps = ["app.grapheneos.gmscompat >= 1007"]
 deps = ["com.google.android.gms"]
 
 description = """


### PR DESCRIPTION
GmsCompat 1007 was released in 2024022300 GrapheneOS release over 5 weeks ago.
