### PR TITLE
don't suppress auto-update notifications for Vanadium WebView

### DIFF
--- a/apps/packages/app.vanadium.webview/common-props.toml
+++ b/apps/packages/app.vanadium.webview/common-props.toml
@@ -4,6 +4,5 @@ hasFsVeritySignatures = true
 group = "Vanadium"
 noIcon = true
 isTopLevel = false
-showAutoUpdateNotifications = false
 deps = ["app.vanadium.trichromelibrary", "app.vanadium.config"]
 staticDeps = ["app.vanadium.webview >= 548106100"]


### PR DESCRIPTION
Auto-update notifications for Vanadium WebView were suppressed because it was previously declared to be a dependency of Vanadium browser, which meant that updating browser always updated the WebView.