### PR TITLE
add GmsCompatConfig to Play services deps

### DIFF
--- a/apps/packages/com.google.android.gms/common-props.toml
+++ b/apps/packages/com.google.android.gms/common-props.toml
@@ -4,7 +4,7 @@ source = "Google"
 staticDeps = ["app.grapheneos.gmscompat >= 1000"]
 # GSF is not needed on SDK 35+, it's excluded there by "android <= 34" staticDep.
 # SkipIfMissing dependency flag makes App Store ignore GSF dependency on SDK 35+.
-deps2 = ["com.google.android.gsf 0 SkipIfMissing", "com.android.vending"]
+deps2 = ["app.grapheneos.gmscompat.config", "com.google.android.gsf 0 SkipIfMissing", "com.android.vending"]
 # deps property is ignored by App Store versions that support the new deps2 property
 deps = ["com.google.android.gsf", "com.android.vending"]
 requestUpdateOwnership = false


### PR DESCRIPTION
This was not needed previously, GmsCompatConfig was a transitive dependency through GSF.