### PR TITLE
remove update ownership opt-out for Play services and Play Store

### DIFF
--- a/apps/packages/com.android.vending/common-props.toml
+++ b/apps/packages/com.android.vending/common-props.toml
@@ -1,7 +1,6 @@
 signatures = ["7ce83c1b71f3d572fed04c8d40c5cb10ff75e6d87d9df6fbd53f0468c2905053"]
 source = "Google"
 isTopLevel = false
-requestUpdateOwnership = false
 
 staticDeps = ["app.grapheneos.gmscompat >= 1000"]
 deps = ["com.google.android.gms"]

--- a/apps/packages/com.google.android.gms/common-props.toml
+++ b/apps/packages/com.google.android.gms/common-props.toml
@@ -7,7 +7,6 @@ staticDeps = ["app.grapheneos.gmscompat >= 1000"]
 deps2 = ["app.grapheneos.gmscompat.config", "com.google.android.gsf 0 SkipIfMissing", "com.android.vending"]
 # deps property is ignored by App Store versions that support the new deps2 property
 deps = ["com.google.android.gsf", "com.android.vending"]
-requestUpdateOwnership = false
 
 description = """
 Official release of Google Play services without modifications. On GrapheneOS, it runs as a regular sandboxed app with no special access or privileges thanks to our sandboxed Google Play compatibility layer. The lack of any of the extensive standard privileged integration into the OS and the compatibility layer teaching it how to function that way are what makes it sandboxed Google Play.


### PR DESCRIPTION
App Store is now responsible for updates of Play services and Play Store.